### PR TITLE
Potential fix for code scanning alert no. 18: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/secret_scanner.yml
+++ b/.github/workflows/secret_scanner.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 on:
   pull_request:
 


### PR DESCRIPTION
Potential fix for [https://github.com/novaferrydianto/devsecops-with-github-actions-end-to-end-nodejs-project/security/code-scanning/18](https://github.com/novaferrydianto/devsecops-with-github-actions-end-to-end-nodejs-project/security/code-scanning/18)

The fix is to add an explicit `permissions` block specifying the least privilege necessary for the workflow. The minimal privilege for this workflow is likely just `contents: read`, which suffices for `actions/checkout` and trufflehog scans. This `permissions` block should be inserted at the root of the workflow (directly under the workflow name and before `on:`) or at the job level if more granular control is needed. In this case, adding `permissions: contents: read` at the root level (just after the workflow name and before `on:`) is sufficient and clear. No additional imports, definitions, or dependencies are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
