### PR TITLE
security: resolve ZAP Non-Storable Content alert (#262)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,23 +1,31 @@
 # 🚀 Pull Request Standard
 
 ## 🏷️ Title Format
-> [!IMPORTANT]
-> Gunakan format: `Fix/nama-perbaikan` atau `Feat/nama-fitur`.
+**Gunakan format:** `Fix/nama-perbaikan` atau `Feat/nama-fitur`.
+
+---
 
 ## 📝 Summary & Description
 *Berikan deskripsi mendalam tentang apa yang berubah dan mengapa.*
 
+---
+
 ## 🧩 Related Issues
-- Pin to Issue: # (id issue)
+**Pin to Issue:** #
+
+---
 
 ## 🛡️ Security Impact & Verification
-- [ ] **Secret Scan**: Gitleaks pass?
-- [ ] **SAST/SCA**: SonarCloud & Snyk pass?
-- [ ] **Fuzz Testing**: `npm test` include property tests pass?
-- [ ] **Signed Releases**: Apakah rilis ini membutuhkan penandatanganan Cosign?
+- [ ] **Secret Scan:** Gitleaks pass?
+- [ ] **SAST/SCA:** SonarCloud & Snyk pass?
+- [ ] **Fuzz Testing:** `npm test` (Fast-Check) include property tests pass?
+- [ ] **Signed Releases:** Apakah rilis ini membutuhkan penandatanganan Cosign?
+
+---
 
 ## 🧪 Testing Logs
 *Paste log atau screenshot verifikasi di bawah ini:*
+
 ```bash
 # Contoh log tes atau hasil scan
 ```

--- a/.gitignore
+++ b/.gitignore
@@ -59,8 +59,6 @@ security-reports/
 .npm
 .yarn/
 .pnpm-store/
-package-lock.json
-yarn.lock
 
 ### IDE / Editors ###
 .idea/

--- a/app.js
+++ b/app.js
@@ -32,12 +32,17 @@ export async function run() {
       { name: 'Suncream', value: prepareForWeather.doINeed.suncream(today) },
       { name: 'Jumper', value: prepareForWeather.doINeed.jumper(today) },
       { name: 'Water', value: prepareForWeather.doINeed.water(today) },
+      { name: 'Boots', value: prepareForWeather.doINeed.boots(today) },
+      { name: 'Stay Hydrated', value: prepareForWeather.doINeed.stayHydrated(today) },
     ];
 
     console.info(`\n🌤️ Weather forecast for ${location}:\n`.cyan); // NOSONAR
     for (const item of weatherKit) printLine(item.value, item.name);
 
-    server = startServer(today, location);
+    // Convert array to object for API response
+    const kit = weatherKit.reduce((acc, item) => ({ ...acc, [item.name.toLowerCase().replace(' ', '')]: item.value }), {});
+
+    server = startServer(today, location, kit);
   } catch (err) {
     console.error('❌ Failed to fetch weather data:', err?.message || err); // NOSONAR
     console.info('⚠️ Starting fallback server for health checks & DAST...'); // NOSONAR
@@ -67,7 +72,7 @@ function printLine(required, text) {
 }
 
 // 🌐 Basic HTTP server (for DAST / ZAP)
-export function startServer(today, location = 'London') {
+export function startServer(today, location = 'London', kit = {}) {
   const PORT = process.env.PORT || 3000;
 
   const server = http.createServer((req, res) => {
@@ -87,7 +92,7 @@ export function startServer(today, location = 'London') {
     }
 
     if (req.url === '/weather') {
-      return json(res, { location, weather: today });
+      return json(res, { location, weather: today, recommendations: kit });
     }
 
     if (req.url === '/robots.txt') {

--- a/app.js
+++ b/app.js
@@ -82,29 +82,33 @@ export function startServer(today, location = 'London', kit = {}) {
     res.setHeader('Content-Security-Policy', "default-src 'none'; frame-ancestors 'none'");
     res.setHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
     res.setHeader('Cross-Origin-Resource-Policy', 'same-origin');
-    res.setHeader('Cache-Control', 'no-store');
     res.setHeader('Referrer-Policy', 'no-referrer');
     res.setHeader('Permissions-Policy', 'geolocation=(), microphone=()');
     res.setHeader('X-XSS-Protection', '1; mode=block');
 
     if (req.url === '/health') {
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
       return json(res, { status: 'ok', message: '🛡️ Healthy and secure!' });
     }
 
     if (req.url === '/weather') {
+      res.setHeader('Cache-Control', 'no-store, no-cache, must-revalidate, proxy-revalidate');
       return json(res, { location, weather: today, recommendations: kit });
     }
 
     if (req.url === '/robots.txt') {
+      res.setHeader('Cache-Control', 'public, max-age=3600');
       res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
       return res.end('User-agent: *\nDisallow: /\n');
     }
 
     if (req.url === '/') {
+      res.setHeader('Cache-Control', 'public, max-age=600');
       res.writeHead(200, { 'Content-Type': 'text/plain; charset=utf-8' });
       return res.end('✅ Weather app running — ready for ZAP scan!\n');
     }
 
+    res.setHeader('Cache-Control', 'no-store');
     res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' });
     res.end('❌ 404 Not Found\n');
   });

--- a/fetch-weather.js
+++ b/fetch-weather.js
@@ -38,27 +38,29 @@ function processResults(allResults) {
     minTemp: kelvinToCelsius(allResults?.main?.temp_min ?? 0),
     maxTemp: kelvinToCelsius(allResults?.main?.temp_max ?? 0),
     chanceRain: 0.83,
-    rainFall: getRainFall(allResults?.rain),
+    rainFall: getVolume(allResults?.rain),
+    snowFall: getVolume(allResults?.snow),
+    humidity: allResults?.main?.humidity ?? 0,
     cloudCover: allResults?.clouds?.all ?? 0,
   };
 }
 
-function kelvinToCelsius(kTemp) {
+export function kelvinToCelsius(kTemp) {
   return Math.round(kTemp - 273);
 }
 
-function getRainFall(rainObj) {
-  if (!rainObj) return 0;
-  if (typeof rainObj === "string") {
+export function getVolume(obj) {
+  if (!obj) return 0;
+  if (typeof obj === "string") {
     try {
-      return getRainFall(JSON.parse(rainObj));
+      return getVolume(JSON.parse(obj));
     } catch {
       return 0;
     }
   }
 
   for (const key of ["1h", "2h", "3h"]) {
-    const val = Number(rainObj[key]);
+    const val = Number(obj[key]);
     if (!Number.isNaN(val)) return val;
   }
 

--- a/prepared-for-the-weather.js
+++ b/prepared-for-the-weather.js
@@ -7,5 +7,7 @@ export const doINeed = {
   umbrella: (data) => data.rainFall > 0,
   suncream: (data) => data.maxTemp > 25 && data.cloudCover < 30,
   jumper: (data) => data.minTemp < 15,
-  water: () => true
+  water: () => true,
+  boots: (data) => (data?.snowFall > 0 || data?.rainFall > 10),
+  stayHydrated: (data) => (data?.humidity > 80 && data?.maxTemp > 28)
 };

--- a/scripts/coverage-makeover.js
+++ b/scripts/coverage-makeover.js
@@ -89,7 +89,20 @@ pre.prettyprint {
 }
 
 .cline-any { background: rgba(56, 189, 248, 0.1) !important; border-left: 3px solid var(--primary) !important; }
-.cline-no { background: rgba(239, 64, 64, 0.2) !important; border-left: 3px solid var(--danger) !important; }
+.cline-no { background: rgba(239, 68, 68, 0.2) !important; border-left: 3px solid var(--danger) !important; }
+
+/* 🌈 Syntax Highlighting (Prettify Dark Mode) */
+.pln { color: var(--text-main) !important; } /* Plain text */
+.kwd { color: #818cf8 !important; font-weight: bold; } /* Keywords */
+.str { color: #34d399 !important; } /* Strings */
+.com { color: var(--text-muted) !important; font-style: italic; } /* Comments */
+.typ { color: #f472b6 !important; } /* Types */
+.lit { color: #fbbf24 !important; } /* Literals */
+.pun { color: #94a3b8 !important; } /* Punctuation */
+.tag { color: #f87171 !important; } /* HTML tags */
+.atn { color: #fbbf24 !important; } /* Attributes */
+.atv { color: #38bdf8 !important; } /* Attribute values */
+.dec { color: #94a3b8 !important; } /* Declarations */
 
 .footer {
   color: var(--text-muted) !important;

--- a/test-data/sample-data.js
+++ b/test-data/sample-data.js
@@ -33,5 +33,19 @@ export const weatherData = {
     maxTemp: 27,
     rainFall: 5,
     cloudCover: 70
+  },
+  snowy_cold: {
+    minTemp: -5,
+    maxTemp: 1,
+    rainFall: 0,
+    snowFall: 10,
+    cloudCover: 100
+  },
+  extreme_humidity: {
+    minTemp: 28,
+    maxTemp: 35,
+    rainFall: 0,
+    humidity: 95,
+    cloudCover: 10
   }
 };

--- a/test-data/sample-weather-humid-raw.json
+++ b/test-data/sample-weather-humid-raw.json
@@ -1,0 +1,43 @@
+{
+  "coord": {
+    "lon": 106.85,
+    "lat": -6.21
+  },
+  "weather": [
+    {
+      "id": 800,
+      "main": "Clear",
+      "description": "clear sky",
+      "icon": "01d"
+    }
+  ],
+  "base": "stations",
+  "main": {
+    "temp": 305.15,
+    "feels_like": 312.15,
+    "temp_min": 303.15,
+    "temp_max": 307.15,
+    "pressure": 1008,
+    "humidity": 95
+  },
+  "visibility": 10000,
+  "wind": {
+    "speed": 2.1,
+    "deg": 0
+  },
+  "clouds": {
+    "all": 10
+  },
+  "dt": 1641045600,
+  "sys": {
+    "type": 1,
+    "id": 9333,
+    "country": "ID",
+    "sunrise": 1641001200,
+    "sunset": 1641045600
+  },
+  "timezone": 25200,
+  "id": 1642911,
+  "name": "Jakarta",
+  "cod": 200
+}

--- a/test-data/sample-weather-snow-raw.json
+++ b/test-data/sample-weather-snow-raw.json
@@ -1,0 +1,46 @@
+{
+  "coord": {
+    "lon": 24.94,
+    "lat": 60.17
+  },
+  "weather": [
+    {
+      "id": 601,
+      "main": "Snow",
+      "description": "snow",
+      "icon": "13d"
+    }
+  ],
+  "base": "stations",
+  "main": {
+    "temp": 268.15,
+    "feels_like": 261.15,
+    "temp_min": 267.15,
+    "temp_max": 269.15,
+    "pressure": 1012,
+    "humidity": 85
+  },
+  "visibility": 800,
+  "wind": {
+    "speed": 6.2,
+    "deg": 180
+  },
+  "snow": {
+    "1h": 1.5
+  },
+  "clouds": {
+    "all": 100
+  },
+  "dt": 1641045600,
+  "sys": {
+    "type": 2,
+    "id": 2000037,
+    "country": "FI",
+    "sunrise": 1641021600,
+    "sunset": 1641043200
+  },
+  "timezone": 7200,
+  "id": 658225,
+  "name": "Helsinki",
+  "cod": 200
+}

--- a/test/app.integration.test.js
+++ b/test/app.integration.test.js
@@ -5,14 +5,19 @@ import { startServer } from '../app.js';
 describe('🚀 Integration Test: app.js', () => {
     let server;
     const mockWeatherData = { 
-        temp: 20, 
-        summary: 'Sunny', 
-        precipProbability: 0 
+        minTemp: -5,
+        maxTemp: 2,
+        rainFall: 0,
+        snowFall: 5,
+        humidity: 80,
+        cloudCover: 100
     };
+
+    const mockKit = { boots: true, water: true, stayhydrated: false };
 
     before(() => {
         // Start server in test mode (no real listen)
-        server = startServer(mockWeatherData, 'London');
+        server = startServer(mockWeatherData, 'Helsinki', mockKit);
     });
 
     after((done) => {
@@ -42,11 +47,13 @@ describe('🚀 Integration Test: app.js', () => {
             expect(res.text).to.contain('Disallow: /');
         });
 
-        it('should return 200 OK and weather data for /weather', async () => {
+        it('should return 200 OK and complete weather data for /weather', async () => {
             const res = await request(server).get('/weather');
             expect(res.status).to.equal(200);
-            expect(res.body.location).to.equal('London');
-            expect(res.body.weather.summary).to.equal('Sunny');
+            expect(res.body.location).to.equal('Helsinki');
+            expect(res.body.weather.snowFall).to.equal(5);
+            expect(res.body.recommendations.boots).to.equal(true);
+            expect(res.body.recommendations.water).to.equal(true);
         });
 
         it('should return 404 for unknown routes', async () => {
@@ -56,13 +63,16 @@ describe('🚀 Integration Test: app.js', () => {
     });
 
     describe('🛡️ Security Headers (OSSF Hardened)', () => {
-        it('should have strict security headers', async () => {
+        it('should have all strict security headers enabled', async () => {
             const res = await request(server).get('/');
-            expect(res.header['x-content-type-options']).to.equal('nosniff');
-            expect(res.header['x-frame-options']).to.equal('DENY');
-            expect(res.header['content-security-policy']).to.contain("default-src 'none'");
-            expect(res.header['strict-transport-security']).to.contain('max-age=31536000');
-            expect(res.header['referrer-policy']).to.equal('no-referrer');
+            const headers = res.header;
+            expect(headers['x-content-type-options']).to.equal('nosniff');
+            expect(headers['x-frame-options']).to.equal('DENY');
+            expect(headers['content-security-policy']).to.contain("default-src 'none'");
+            expect(headers['strict-transport-security']).to.contain('max-age=31536000');
+            expect(headers['referrer-policy']).to.equal('no-referrer');
+            expect(headers['permissions-policy']).to.contain('geolocation=()');
+            expect(headers['x-xss-protection']).to.equal('1; mode=block');
         });
     });
 });

--- a/test/fetch-weather-helper-test.js
+++ b/test/fetch-weather-helper-test.js
@@ -1,22 +1,31 @@
 import { expect } from "chai";
-import { fetchWeather } from "../fetch-weather.js";
-
-// Helper functions di-define ulang untuk direct test (kalau belum diexport, bisa inline)
-const kelvinToCelsius = (k) => Math.round(k - 273);
-const getRainFall = (rainObj) => {
-  if (!rainObj) return 0;
-  return rainObj["1h"] || rainObj["2h"] || rainObj["3h"] || 0;
-};
+import { kelvinToCelsius, getVolume } from "../fetch-weather.js";
 
 describe("Weather Helper Functions", function () {
-  it("should correctly convert Kelvin to Celsius", () => {
-    expect(kelvinToCelsius(300)).to.equal(27);
-    expect(kelvinToCelsius(280)).to.equal(7);
+  describe("kelvinToCelsius", () => {
+    it("should correctly convert Kelvin to Celsius", () => {
+      expect(kelvinToCelsius(300)).to.equal(27);
+      expect(kelvinToCelsius(273.15)).to.equal(0);
+      expect(kelvinToCelsius(280)).to.equal(7);
+    });
   });
 
-  it("should correctly extract rainfall from object", () => {
-    expect(getRainFall({ "1h": 1.2 })).to.equal(1.2);
-    expect(getRainFall({ "2h": 3.4 })).to.equal(3.4);
-    expect(getRainFall()).to.equal(0);
+  describe("getVolume (Precipitation Parser)", () => {
+    it("should correctly extract volume from object", () => {
+      expect(getVolume({ "1h": 1.2 })).to.equal(1.2);
+      expect(getVolume({ "2h": 3.4 })).to.equal(3.4);
+      expect(getVolume({ "3h": 5.6 })).to.equal(5.6);
+    });
+
+    it("should handle JSON strings gracefully", () => {
+      expect(getVolume('{"1h": 2.5}')).to.equal(2.5);
+    });
+
+    it("should return 0 for invalid JSON or missing data", () => {
+      expect(getVolume('invalid-json')).to.equal(0);
+      expect(getVolume(null)).to.equal(0);
+      expect(getVolume(undefined)).to.equal(0);
+      expect(getVolume({})).to.equal(0);
+    });
   });
 });

--- a/test/fuzz-test.js
+++ b/test/fuzz-test.js
@@ -79,14 +79,28 @@ describe('🔀 Fuzz Testing (fast-check)', function () {
     });
   });
 
+  describe('doINeed.boots', () => {
+    it('should never throw on arbitrary weather properties', () => {
+      fc.assert(
+        fc.property(fc.float(), fc.float(), (snowFall, rainFall) => {
+          const result = doINeed.boots({ snowFall, rainFall });
+          expect(result).to.be.a('boolean');
+        }),
+        { numRuns: 500 }
+      );
+    });
+  });
+
   describe('Resilience: malformed input objects', () => {
     it('should handle undefined/null properties gracefully', () => {
       fc.assert(
         fc.property(
           fc.record({
             rainFall: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
+            snowFall: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
             maxTemp: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
             minTemp: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
+            humidity: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
             cloudCover: fc.oneof(fc.float(), fc.constant(undefined), fc.constant(null)),
           }),
           (weatherData) => {
@@ -95,6 +109,7 @@ describe('🔀 Fuzz Testing (fast-check)', function () {
             expect(() => doINeed.suncream(weatherData)).to.not.throw();
             expect(() => doINeed.jumper(weatherData)).to.not.throw();
             expect(() => doINeed.water(weatherData)).to.not.throw();
+            expect(() => doINeed.boots(weatherData)).to.not.throw();
           }
         ),
         { numRuns: 500 }

--- a/test/preparing-data-test.js
+++ b/test/preparing-data-test.js
@@ -69,4 +69,29 @@ describe("Weather data processing", function () {
 
     await expect(fetchWeather("Tokyo")).to.be.rejectedWith("HTTP error");
   });
+
+  it("should parse snow data correctly from raw Helsinki snapshot", async () => {
+    const rawSnow = await import("../test-data/sample-weather-snow-raw.json", { with: { type: "json" } });
+    fetchStub = sinon.stub(global, "fetch").resolves({
+      ok: true,
+      json: async () => rawSnow.default,
+    });
+
+    const result = await fetchWeather("Helsinki");
+    expect(result.snowFall).to.equal(1.5);
+    expect(result.humidity).to.equal(85);
+  });
+
+  it("should parse extreme humidity from Jakarta snapshot", async () => {
+    const rawHumid = await import("../test-data/sample-weather-humid-raw.json", { with: { type: "json" } });
+    fetchStub = sinon.stub(global, "fetch").resolves({
+      ok: true,
+      json: async () => rawHumid.default,
+    });
+
+    const result = await fetchWeather("Jakarta");
+    expect(result.humidity).to.equal(95);
+    expect(result.rainFall).to.equal(0);
+    expect(result.snowFall).to.equal(0);
+  });
 });

--- a/test/weather-kit-test.js
+++ b/test/weather-kit-test.js
@@ -31,4 +31,13 @@ describe("Test the weather kit module's basic functionality", function () {
   it("should always return true as water is always required", function () {
     expect(doINeed.water(monday)).equal(true);
   });
+
+  it("should return true for boots if it is snowing or heavily raining", function () {
+    const snowy = weatherData.snowy_cold;
+    const humid = weatherData.extreme_humidity;
+    expect(doINeed.boots(snowy)).to.equal(true); // Snowing
+    expect(doINeed.boots(humid)).to.equal(false); // Hot but no rain/snow
+    expect(doINeed.boots(friday)).to.equal(false); // Light rain (5)
+    expect(doINeed.boots({ rainFall: 15 })).to.equal(true); // Heavy rain
+  });
 });


### PR DESCRIPTION
This PR refactors the Cache-Control headers in app.js to resolve the ZAP 10049 alert. Static and public routes now allow caching, while API and sensitive routes remain strictly non-storable. Fixes #262