### PR TITLE
ci: fix SARIF validation in Scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -46,6 +46,11 @@ jobs:
           
           publish_results: true
 
+      - name: "Sanitize SARIF"
+        # Menghapus teks "no file associated with this alert" dan menggantinya dengan "."
+        # agar valid di GitHub Code Scanning.
+        run: sed -i 's/no file associated with this alert/./g' results.sarif
+
       - name: "Upload artifact"
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         env:


### PR DESCRIPTION
This PR adds a sanitization step to the Scorecard workflow to replace invalid URIs in the SARIF output. This addresses the 'no file associated with this alert' validation warning when uploading to GitHub Code Scanning.