### PR TITLE
Enhance Dockerfile with security improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,40 +1,60 @@
 # =================================================================
-# STAGE 1: Build & Dependencies
+# STAGE 1: Build & Dependencies  (has npm + shell)
 # =================================================================
 FROM cgr.dev/chainguard/node:latest-dev@sha256:c9558c9f98f50207fa5cd24366a84d788b1e82d2d54bbb8c50b21324b55649ed AS builder
-
-# Set context ke user node sejak awal
+# (Builder may carry a vulnerable npm — that's fine, it is DISCARDED and never
+#  reaches the runtime image. Still, repull periodically for good hygiene.)
 WORKDIR /app
 
-# ✅ FIX: Tambahkan --chown=node:node agar npm punya izin akses
+# Install deps first (better layer caching). --chown so npm has write access.
 COPY --chown=node:node package.json package-lock.json ./
 
-RUN npm ci --include=dev
+# No build step here, so install production deps only and skip a separate prune.
+# ⚠️ If you DO have a build step (tsc/webpack/etc.) that needs devDependencies,
+#    revert to:  RUN npm ci --include=dev  ->  <your build>  ->  RUN npm prune --omit=dev
+RUN npm ci --omit=dev
 
-# ✅ FIX: Pastikan source code juga dimiliki oleh user node
+# App source
 COPY --chown=node:node . .
 
-# Sekarang npm prune tidak akan kena EACCES
-RUN npm prune --production
-
 # =================================================================
-# STAGE 2: Hardened Runtime
+# STAGE 2: Hardened Runtime  (-slim => NO npm, NO shell)
+# This is the fix for the 5 HIGH npm CVEs: the npm CLI simply isn't present.
 # =================================================================
-FROM cgr.dev/chainguard/node:latest@sha256:93f09480a25e5e3c25f70856bacf4c35572522faed0182a4cbff5032958c65ef
-
+FROM cgr.dev/chainguard/node:latest-slim
+# TODO: pin by digest AFTER you pull it, e.g.
+#   cgr.dev/chainguard/node:latest-slim@sha256:<resolve in your env>
 WORKDIR /app
 
-# ✅ Salin file dengan user node
-COPY --chown=node:node --from=builder /app/node_modules ./node_modules
-COPY --chown=node:node --from=builder /app/*.js ./
-COPY --chown=node:node --from=builder /app/package.json ./
+# Distroless runtime has NO shell -> `RUN chmod` is impossible here.
+# We bake read+execute-only permissions at copy time with BuildKit's --chmod
+# (same hardening intent as your old `chmod -R 550`, no shell required).
+COPY --from=builder --chown=node:node --chmod=550 /app/node_modules ./node_modules
 
-# ✅ FIX UNTUK COPILOT: Hilangkan izin tulis (Write) untuk user node
-# Ini memastikan file tidak bisa diubah jika container disusupi
-USER root
-RUN chmod -R 550 /app && chmod -R 440 /app/package.json
+# ⚠️ This copies ONLY root-level *.js. If your app has subfolders or assets
+#    (views/, public/, routes/, src/, *.json configs, *.ejs, *.hbs ...),
+#    ADD explicit COPY lines for them or they will be MISSING at runtime.
+#    Example:
+#      COPY --from=builder --chown=node:node --chmod=550 /app/views ./views
+#      COPY --from=builder --chown=node:node --chmod=550 /app/public ./public
+COPY --from=builder --chown=node:node --chmod=550 /app/*.js ./
+COPY --from=builder --chown=node:node --chmod=440 /app/package.json ./
+
+# No USER root needed: Chainguard node images already default to the nonroot
+# `node` user, and permissions were set above at copy time.
 USER node
-
 ENV NODE_ENV=production
 EXPOSE 3000
+
+# The Chainguard node image ENTRYPOINT is `node`, so this runs: node app.js
 CMD ["app.js"]
+
+# --- Optional, defense-in-depth (uncomment if desired) ---
+# Liveness without curl/wget (none exist in slim) — uses node itself:
+# HEALTHCHECK --interval=30s --timeout=3s --start-period=10s --retries=3 \
+#   CMD ["node","-e","require('http').get('http://127.0.0.1:3000',r=>process.exit(r.statusCode<500?0:1)).on('error',()=>process.exit(1))"]
+#
+# Prefer enforcing immutability at RUNTIME instead of (or in addition to) the
+# chmod above — it is more robust than baked file modes:
+#   k8s:    securityContext.readOnlyRootFilesystem: true
+#   docker: docker run --read-only --tmpfs /tmp ...


### PR DESCRIPTION
Refactor Dockerfile to improve security and permissions management.

## 📝 Description
Fixes #(issue_number)

## 🎯 Type of Change
- [ ] ✨ Feat (New feature)
- [ ] 🐛 Fix (Bug fix)
- [ ] 🧹 Chore (Refactoring, dependencies, etc)
- [ ] 🛡️ Security (Security patches)
- [ ] 🏗️ IaC/Infra (Terraform, K8s manifests, CI/CD)
- [ ] 📖 Docs (Documentation changes)

## 🔍 Proposed Changes
- [ ] List of specific changes...
- [ ] List of specific changes...

## 🛡️ DevSecOps & Quality Checklist
- [ ] **Linting & Formatting**: Code follows the project's style guide.
- [ ] **Security Scanning**: No high/critical vulnerabilities found (Snyk/Trivy/SonarQube).
- [ ] **Secrets**: No hardcoded secrets or credentials included.
- [ ] **IaC Validation**: `terraform plan` or `tofu plan` shows expected changes (if applicable).
- [ ] **Tests**: Unit tests or Integration tests passed.
- [ ] **Documentation**: Updated README or internal docs if necessary.

## 🧪 How Has This Been Tested?
- **Test Environment**: [e.g., Local Podman, GKE Staging, etc.]
- **Test Command**: `make test` or `go test ./...`
- **Result**: [Attach screenshots or logs if relevant]

## 📸 Screenshots / Logs (Optional)
## 🚩 Risk Assessment
- **Downtime**: [Yes/No]
- **Migration Required**: [Yes/No]
- **Rollback Plan**: ```

### **Result**
Dengan menggunakan template ini, tim Anda akan mendapatkan manfaat berikut:
1.  **Standardisasi**: Setiap PR memiliki struktur yang sama, memudahkan Senior Engineer melakukan *review*.
2.  **Keamanan Terjamin**: Checklist keamanan memaksa developer untuk memeriksa *vulnerabilities* sebelum melakukan *merge*.
3.  **Audit Trail**: Memiliki catatan yang jelas mengenai bagaimana fitur diuji dan apa rencana *rollback*-nya jika terjadi insiden (SRE Best Practice).
4.  **Efficiency**: Mengurangi *back-and-forth* antara reviewer dan author karena informasi sudah lengkap di awal.

**Pro-tip from SRE Perspective:** Jika Anda menggunakan **Terragrunt/OpenTofu**, pastikan untuk selalu melampirkan output `plan` di bagian "Screenshots / Logs" agar reviewer bisa memvalidasi perubahan *state* tanpa harus menjalankan command secara manual.
