### PR TITLE
fix(ci): bind DAST test container to the Docker bridge gateway only

### DIFF
--- a/.github/workflows/devsecops-pipeline.yaml
+++ b/.github/workflows/devsecops-pipeline.yaml
@@ -435,23 +435,40 @@ jobs:
         run: |
           set -euo pipefail
           docker load -i image.tar
-          docker run -d --name app -p 3000:3000 \
+
+          # Trust boundary: this endpoint exists only on the ephemeral runner's
+          # local Docker bridge. Bind it to that interface instead of 0.0.0.0 so
+          # it is unreachable from the runner's other network interfaces.
+          readonly HOST_GW="$(docker network inspect bridge \
+            --format '{{ (index .IPAM.Config 0).Gateway }}')"
+          if ! [[ "$HOST_GW" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
+            echo "::error::Docker bridge returned an invalid IPv4 gateway"
+            exit 1
+          fi
+
+          docker run -d --name app -p "${HOST_GW}:3000:3000" \
             -e OPENWEATHER_API_KEY="dummy" \
             "${{ env.LOCAL_IMAGE }}"
 
           # Readiness probe instead of a blind sleep.
+          READY=false
           for i in $(seq 1 30); do
-            if curl -sf http://localhost:3000 >/dev/null 2>&1; then
-              echo "App is up (attempt $i)."; break
+            if curl --fail --silent --show-error \
+              --max-time 2 "http://${HOST_GW}:3000" >/dev/null; then # NOSONAR
+              echo "App is up (attempt $i)."
+              READY=true
+              break
             fi
             sleep 2
           done
+          if [[ "$READY" != true ]]; then
+            echo "::error::App did not become ready for the ZAP scan"
+            docker logs app
+            exit 1
+          fi
 
-          # Resolve the Docker bridge gateway dynamically (no hardcoded 172.17.0.1),
-          # so the ZAP container can reach the published host port reliably.
-          HOST_GW=$(docker network inspect bridge -f '{{ (index .IPAM.Config 0).Gateway }}')
-          # Internal Docker-bridge traffic to our own plain-HTTP test server (no TLS
-          # exists to scan) -- not a real endpoint, so cleartext here is expected.
+          # Intentional cleartext: ZAP reaches only this bridge-bound, ephemeral
+          # test endpoint. No credentials or production data traverse the link.
           echo "ZAP_TARGET=http://${HOST_GW}:3000" >> "$GITHUB_ENV" # NOSONAR
 
       - name: ZAP Baseline Scan

--- a/.github/workflows/devsecops-pipeline.yaml
+++ b/.github/workflows/devsecops-pipeline.yaml
@@ -439,8 +439,9 @@ jobs:
           # Trust boundary: this endpoint exists only on the ephemeral runner's
           # local Docker bridge. Bind it to that interface instead of 0.0.0.0 so
           # it is unreachable from the runner's other network interfaces.
-          readonly HOST_GW="$(docker network inspect bridge \
+          HOST_GW="$(docker network inspect bridge \
             --format '{{ (index .IPAM.Config 0).Gateway }}')"
+          readonly HOST_GW
           if ! [[ "$HOST_GW" =~ ^([0-9]{1,3}\.){3}[0-9]{1,3}$ ]]; then
             echo "::error::Docker bridge returned an invalid IPv4 gateway"
             exit 1

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,10 +18,10 @@ sonar.sourceEncoding=UTF-8
 
 # Issue exclusions
 # githubactions:S5332 (clear-text protocol) on devsecops-pipeline.yaml: the flagged
-# line is `ZAP_TARGET=http://${HOST_GW}:3000`, which routes only over the ephemeral
-# GitHub Actions runner's local Docker bridge network to our own plain-HTTP DAST
-# test container -- never a real network hop, no TLS endpoint exists to use.
-# Also marked "Won't Fix" in the SonarCloud UI for this same reason.
+# lines are the readiness probe and `ZAP_TARGET=http://${HOST_GW}:3000`. The
+# service port is bound exclusively to the ephemeral runner's Docker bridge
+# gateway (not 0.0.0.0), carries no credentials or production data, and exists
+# only for the duration of this DAST job. There is no TLS endpoint to use.
 sonar.issue.ignore.multicriteria=e1
 sonar.issue.ignore.multicriteria.e1.ruleKey=githubactions:S5332
 sonar.issue.ignore.multicriteria.e1.resourceKey=.github/workflows/devsecops-pipeline.yaml


### PR DESCRIPTION
Previously `docker run -p 3000:3000` bound the ephemeral test container to 0.0.0.0 (every interface on the runner), and the readiness probe hit it via localhost. Now:

- Resolve the bridge gateway IP up front and validate it's a well-formed IPv4 address before using it (fail closed with a clear error if not).
- Bind the published port explicitly to that gateway IP (`-p "${HOST_GW}:3000:3000"`), not all interfaces.
- Point the readiness probe at the same bridge-gateway URL (with an explicit --max-time) instead of localhost, and actually fail the job with the container logs if the app never becomes ready -- previously the retry loop would silently exhaust and continue straight into the ZAP scan against a target that may never have come up.

Also updated the sonar-project.properties exclusion comment for githubactions:S5332 to reflect the bridge-only binding as additional justification (no credentials/production data, bound to a single non-routable interface, ephemeral for the job's duration).

## 📝 Description
Fixes #(issue_number)

## 🎯 Type of Change
- [ ] ✨ Feat (New feature)
- [ ] 🐛 Fix (Bug fix)
- [ ] 🧹 Chore (Refactoring, dependencies, etc)
- [ ] 🛡️ Security (Security patches)
- [ ] 🏗️ IaC/Infra (Terraform, K8s manifests, CI/CD)
- [ ] 📖 Docs (Documentation changes)

## 🔍 Proposed Changes
- [ ] List of specific changes...
- [ ] List of specific changes...

## 🛡️ DevSecOps & Quality Checklist
- [ ] **Linting & Formatting**: Code follows the project's style guide.
- [ ] **Security Scanning**: No high/critical vulnerabilities found (Snyk/Trivy/SonarQube).
- [ ] **Secrets**: No hardcoded secrets or credentials included.
- [ ] **IaC Validation**: `terraform plan` or `tofu plan` shows expected changes (if applicable).
- [ ] **Tests**: Unit tests or Integration tests passed.
- [ ] **Documentation**: Updated README or internal docs if necessary.

## 🧪 How Has This Been Tested?
- **Test Environment**: [e.g., Local Podman, GKE Staging, etc.]
- **Test Command**: `make test` or `go test ./...`
- **Result**: [Attach screenshots or logs if relevant]

## 📸 Screenshots / Logs (Optional)
## 🚩 Risk Assessment
- **Downtime**: [Yes/No]
- **Migration Required**: [Yes/No]
- **Rollback Plan**: ```

### **Result**
Dengan menggunakan template ini, tim Anda akan mendapatkan manfaat berikut:
1.  **Standardisasi**: Setiap PR memiliki struktur yang sama, memudahkan Senior Engineer melakukan *review*.
2.  **Keamanan Terjamin**: Checklist keamanan memaksa developer untuk memeriksa *vulnerabilities* sebelum melakukan *merge*.
3.  **Audit Trail**: Memiliki catatan yang jelas mengenai bagaimana fitur diuji dan apa rencana *rollback*-nya jika terjadi insiden (SRE Best Practice).
4.  **Efficiency**: Mengurangi *back-and-forth* antara reviewer dan author karena informasi sudah lengkap di awal.

**Pro-tip from SRE Perspective:** Jika Anda menggunakan **Terragrunt/OpenTofu**, pastikan untuk selalu melampirkan output `plan` di bagian "Screenshots / Logs" agar reviewer bisa memvalidasi perubahan *state* tanpa harus menjalankan command secara manual.
