### PR TITLE
fix(ci): lock top-level permissions in actionlint workflow for Scorecard 10/10

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -16,16 +16,18 @@ concurrency:
   group: actionlint-${{ github.ref }}
   cancel-in-progress: true
 
-# ✅ PoLP: Read repo content, write check annotations for reviewdog
+# ✅ PoLP: Global lockdown to read-only
 permissions:
   contents: read
-  checks: write
 
 jobs:
   actionlint:
     runs-on: ubuntu-latest
     name: 🧩 Check YAML Quality
     timeout-minutes: 5
+    permissions:
+      contents: read
+      checks: write
     steps:
       # ✅ Hardened: SHA Pinning untuk checkout
       - name: Harden the runner (Audit all outbound calls)


### PR DESCRIPTION
## ��� Description
Moves `checks: write` permission from top-level to job-level in `actionlint.yml` to achieve 10/10 compliance on OpenSSF Scorecard `Token-Permissions` rule.
## ���️ DevSecOps Checklist
- [x] Top-level permissions set to `contents: read`
- [x] Job-level permissions explicitly declare `checks: write`